### PR TITLE
Fix incorrect use of WEXITSTATUS

### DIFF
--- a/wrapper.C
+++ b/wrapper.C
@@ -985,11 +985,35 @@ int main(int argc, char** argv)
         if (t.poll(status))
         {
 #ifndef _WIN32
-            int child_ret_val = WEXITSTATUS(status);
-            if (child_ret_val)
+            if (WIFEXITED(status)) 
             {
-                std::cerr << "app error: " <<  status << std::endl;
-                boinc_finish(status);
+                // process exited by calling exit() or returning from main
+                int child_ret_val = WEXITSTATUS(status);
+                std::cerr << "LLR exited with code: " 
+                    <<  child_ret_val << std::endl;
+                if (child_ret_val != 0) { 
+                    // LLR exited with a non-zero exit status
+                    boinc_finish(child_ret_val);
+                }
+            }
+            else if (WIFSIGNALED(status))
+            {
+                int signal_number = WTERMSIG(status);
+                std::cerr << "LLR got signal: " 
+                    << signal_number
+                    << " "
+                    << strsignal(signal_number)
+                    << std::endl;
+                // The boinc client already has code to handle workers dying by
+                // various signals, so let it do so by imitating the signal llr
+                // recieved: for example, this will prevent workers who recieve
+                // SIGTERM during shutdown from being reported as errors or
+                // invalid results.
+                // see: https://github.com/BOINC/boinc/blob/client_release/7/7.16/client/app_control.cpp#L561
+                kill(getpid(), signal_number); // suicide by imitation
+                // this code should be unreachable
+                // just in case, fall back calling boinc_finish
+                boinc_finish(signal_number);
             }
 #endif
             break;


### PR DESCRIPTION
This fixes handling of LLR executable dying by signals such as SIGKILL or segmentation fault, and removes erroneous use of WEXITSTATUS without checking WIFEXITED first.

Examples of LLR dying with segmentation faults on linux:
Old behavior: https://www.primegrid.com/result.php?resultid=1025153963
New behavior: https://www.primegrid.com/result.php?resultid=1025189018

I have tested this on linux. I have not tested it on OS X. Windows is not affected.